### PR TITLE
boilerplate: reduce & add project name

### DIFF
--- a/templates/boilerplate
+++ b/templates/boilerplate
@@ -1,13 +1,3 @@
+// github.com/web-animations/web-animations-js
 // Copyright 2014 Google Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-//     You may obtain a copy of the License at
-//
 // http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//     See the License for the specific language governing permissions and
-// limitations under the License.


### PR DESCRIPTION
- project name to help determine what the script is when filename is lost (eg concoction)  Listed as URL, since Googling 'google web animations` is not too likely to land here ;)
- removed license details; if people want to 'obey' the license, they either already know what it is or can follow the URL. Otherwise, eats bandwidth & storage space (more worried about mobile)

cheers
