### PR TITLE
+ CDN Availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,8 @@ can't avoid it by not updating*.
 
 We also announce anything that isn't a bug fix on
 [web-animations-changes@googlegroups.com](https://groups.google.com/forum/#!forum/web-animations-changes).
+
+CDN Availability
+----------------
+
+The latest `web-animations.min.js` is available at [jsDelivr CDN](http://www.jsdelivr.com/#!web-animations)


### PR DESCRIPTION
Added project link to jsDelivr CDN website.  A bot will update within an hour when a new [release](https://github.com/web-animations/web-animations-js/releases) is tagged.
Not sure if you want all the [fancy aliasing & concocting](https://github.com/jsdelivr/jsdelivr#url-structure) listed.