### PR TITLE
Use a SPDX-compatible license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "polyfill"
   ],
   "homepage": "https://github.com/web-animations",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "main": "web-animations.min.js",
   "files": [
     "*.min.js",


### PR DESCRIPTION
This fixes an npm warning:

```
npm WARN EPACKAGEJSON web-animations-js@2.1.4 license should be a valid SPDX license expression
```
