### PR TITLE
Fix source map file not exists issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "node_modules",
     "templates",
     "test",
-    "src",
     "Gruntfile.js",
     "package.json",
     "target-config.js",


### PR DESCRIPTION
Fixed error while installed .map file referencing non exists files
