### PR TITLE
Don't ignore src/ directory for bower installs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "node_modules",
     "templates",
     "test",
-    "src",
     "Gruntfile.js",
     "package.json",
     "target-config.js",


### PR DESCRIPTION
The src/ files are necessary for source maps to work.

This pull request is based on https://github.com/web-animations/web-animations-js/pull/76 using the newest dev branch instead of master.