### PR TITLE
Fall back to webkitRequestAnimationFrame

### DIFF
--- a/src/tick.js
+++ b/src/tick.js
@@ -14,7 +14,7 @@
 
 'use strict';
 (function(shared, scope, testing) {
-  var originalRequestAnimationFrame = window.requestAnimationFrame;
+  var originalRequestAnimationFrame = window.requestAnimationFrame || window.webkitRequestAnimationFrame;
   var rafCallbacks = [];
   var rafId = 0;
   window.requestAnimationFrame = function(f) {


### PR DESCRIPTION
When requestAnimationFrame is not present, use
webkitRequestAnimationFrame instead.

This assists users running Chrome versions earlier than 24.

Fixes #112