### PR TITLE
Update color handler test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
- - "4.4.4"
+ - "6.10.2"
 
 install:
   - BROWSER="Firefox-stable" ./.travis-setup.sh

--- a/test/js/color-handler.js
+++ b/test/js/color-handler.js
@@ -11,7 +11,7 @@ suite('color-handler', function() {
   test('invalid colors fail to parse', function() {
     assert.isUndefined(parseColor(''));
     assert.isUndefined(parseColor('bananayellow'));
-    assert.isUndefined(parseColor('rgb(10, 20, 30, 40)'));
+    assert.isUndefined(parseColor('rgb(10, 20, 30, 40, 50)'));
   });
   test('color interpolation', function() {
     assert.equal(webAnimations1.propertyInterpolation('color', '#00aa11', '#aa00bb')(0.2), 'rgba(34,136,51,1)');


### PR DESCRIPTION
The color-handler.js test fails in Firefox after they changed what they accept for rgb() syntax.
See draft spec: https://drafts.csswg.org/css-color/#rgb-functions
Updated test to check a different value.