### PR TITLE
Update the node version Travis uses to 6.10.2 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
- - "4.4.4"
+ - "6.10.2"
 
 install:
   - BROWSER="Firefox-stable" ./.travis-setup.sh


### PR DESCRIPTION
Travis was having problems with `npm install` lo-dash sha numbers. This change updates the node version we use (long overdue) in the hopes that the problem will go away.