### PR TITLE
Specify earliest supported Chrome version.

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -13,7 +13,7 @@ Browser support
 
 The polyfill is supported on modern versions of all major browsers, including:
 
-* Chrome
+* Chrome 55+
 * Firefox 27+
 * IE10+ (including Edge)
 * Safari (iOS) 7.1+


### PR DESCRIPTION
We support Chrome 55+.

Anbody using Chrome 23 or earlier would be affected by
https://github.com/web-animations/web-animations-js/issues/112

Anybody using old versions of Chrome is vulnerable to known
security issues, so we encourage people to use recent Chrome
versions.