### PR TITLE
Support unitless strokeDashoffset values

### DIFF
--- a/src/number-handler.js
+++ b/src/number-handler.js
@@ -88,6 +88,7 @@
   scope.addPropertiesHandler(parseNumber, mergeFlex, ['flex-grow', 'flex-shrink']);
   scope.addPropertiesHandler(parseNumber, mergePositiveIntegers, ['orphans', 'widows']);
   scope.addPropertiesHandler(parseNumber, round, ['z-index']);
+  scope.addPropertiesHandler(parseNumber, mergeNumbers, ['stroke-dashoffset']);
 
   scope.parseNumber = parseNumber;
   scope.parseNumberList = parseNumberList;

--- a/test/js/number-handler.js
+++ b/test/js/number-handler.js
@@ -39,4 +39,7 @@ suite('number-handler', function() {
     assert.equal(interpolation(-1), '0');
     assert.equal(interpolation(2), '1');
   });
+  test('unitless stroke-dashoffset interpolation', function() {
+    assert.equal(webAnimations1.propertyInterpolation('strokeDashoffset', '10', '50')(0.25), '20');
+  });
 });


### PR DESCRIPTION
We currently support animating strokeDashoffset using length values e.g. '10px' but it's also value to specify them without units e.g. '10'.
This change adds support for this syntax and fixes https://github.com/web-animations/web-animations-js/issues/98.