### PR TITLE
Update README.md with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Here's a simple example of an animation that fades and scales a `<div>`.
 </script>
 ```
 
+Install
+-----------
+
+Install the [npm](https://www.npmjs.com/package/web-animations-js) package:
+
+`npm install web-animations-js`
+
+then use web-animation-js as either a CommonJS or an ES2015 module:
+
+CommonJS module: `require('web-animation-js')`
+or ES2015 module: `import 'web-animation-js'`
+
+This will requires a module bundler such as [Browserify](http://browserify.org/), [Webpack](https://webpack.js.org), or [Rollup](https://rollupjs.org/).
+
 Documentation
 -------------
 


### PR DESCRIPTION
Add installation instructions. The README didn't reference npm even though there is an npm package: #134 had a TODO for adding the installation instructions to the README.

Are these installation instructions right? Or is it `require('web-animation-js').polyfill()` instead of just `require('web-animation-js')`?

Thank you for your work on this library and the cool demos.