### PR TITLE
Support IE/Edge SVG transforms

### DIFF
--- a/src/apply-preserving-inline-style.js
+++ b/src/apply-preserving-inline-style.js
@@ -20,12 +20,13 @@
    * See https://connect.microsoft.com/IE/feedback/details/811744/ie11-bug-with-implementation-of-css-transforms-in-svg,
    * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/1173754/,
    * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101242/, etc.
+   * The same problem is exhibited by pre-Chrome Android browsers (ICS).
    * Unfortunately, there's no easy way to feature-detect it.
    */
   function updateSvgTransformAttr(window) {
     if (window._webAnimationsUpdateSvgTransformAttr == null) {
       window._webAnimationsUpdateSvgTransformAttr =
-          /Trident|MSIE|IEMobile|Edge/i.test(window.navigator.userAgent);
+          /Trident|MSIE|IEMobile|Edge|Android 4/i.test(window.navigator.userAgent);
     }
     return window._webAnimationsUpdateSvgTransformAttr;
   }

--- a/src/matrix-decomposition.js
+++ b/src/matrix-decomposition.js
@@ -435,5 +435,6 @@
 
   scope.dot = dot;
   scope.makeMatrixDecomposition = makeMatrixDecomposition;
+  scope.transformListToMatrix = convertToMatrix;
 
 })(webAnimations1, webAnimationsTesting);

--- a/src/property-names.js
+++ b/src/property-names.js
@@ -14,15 +14,15 @@
 
 (function(scope, testing) {
 
-  var aliased = {};
-  var canonical = {};
+  var prefixed = {};
+  var unprefixed = {};
 
   function alias(name, aliases) {
     aliases.concat([name]).forEach(function(candidate) {
       if (candidate in document.documentElement.style) {
-        aliased[name] = candidate;
+        prefixed[name] = candidate;
       }
-      canonical[candidate] = name;
+      unprefixed[candidate] = name;
     });
   }
   alias('transform', ['webkitTransform', 'msTransform']);
@@ -31,10 +31,10 @@
   alias('perspectiveOrigin', ['webkitPerspectiveOrigin']);
 
   scope.propertyName = function(property) {
-    return aliased[property] || property;
+    return prefixed[property] || property;
   };
-  scope.canonicalPropertyName = function(property) {
-    return canonical[property] || property;
+  scope.unprefixedPropertyName = function(property) {
+    return unprefixed[property] || property;
   };
 
 })(webAnimations1, webAnimationsTesting);

--- a/src/property-names.js
+++ b/src/property-names.js
@@ -15,12 +15,14 @@
 (function(scope, testing) {
 
   var aliased = {};
+  var canonical = {};
 
   function alias(name, aliases) {
     aliases.concat([name]).forEach(function(candidate) {
       if (candidate in document.documentElement.style) {
         aliased[name] = candidate;
       }
+      canonical[candidate] = name;
     });
   }
   alias('transform', ['webkitTransform', 'msTransform']);
@@ -30,6 +32,9 @@
 
   scope.propertyName = function(property) {
     return aliased[property] || property;
+  };
+  scope.canonicalPropertyName = function(property) {
+    return canonical[property] || property;
   };
 
 })(webAnimations1, webAnimationsTesting);

--- a/src/transform-handler.js
+++ b/src/transform-handler.js
@@ -256,6 +256,19 @@
 
   scope.addPropertiesHandler(parseTransform, mergeTransforms, ['transform']);
 
+  scope.transformToMatrix2d = function(string) {
+    // matrix(<a> <b> <c> <d> <e> <f>)
+    var mat = scope.transformListToMatrix(parseTransform(string));
+    return 'matrix(' +
+        numberToLongString(mat[0])  + ' ' +  // <a>
+        numberToLongString(mat[1])  + ' ' +  // <b>
+        numberToLongString(mat[4])  + ' ' +  // <c>
+        numberToLongString(mat[5])  + ' ' +  // <d>
+        numberToLongString(mat[12]) + ' ' +  // <e>
+        numberToLongString(mat[13]) +        // <f>
+        ')';
+  };
+
   if (WEB_ANIMATIONS_TESTING)
     testing.parseTransform = parseTransform;
 

--- a/src/transform-handler.js
+++ b/src/transform-handler.js
@@ -256,14 +256,14 @@
 
   scope.addPropertiesHandler(parseTransform, mergeTransforms, ['transform']);
 
-  scope.transformToMatrix2d = function(string) {
+  scope.transformToSvgMatrix = function(string) {
     // matrix(<a> <b> <c> <d> <e> <f>)
     var mat = scope.transformListToMatrix(parseTransform(string));
     return 'matrix(' +
-        numberToLongString(mat[0])  + ' ' +  // <a>
-        numberToLongString(mat[1])  + ' ' +  // <b>
-        numberToLongString(mat[4])  + ' ' +  // <c>
-        numberToLongString(mat[5])  + ' ' +  // <d>
+        numberToLongString(mat[0]) + ' ' +  // <a>
+        numberToLongString(mat[1]) + ' ' +  // <b>
+        numberToLongString(mat[4]) + ' ' +  // <c>
+        numberToLongString(mat[5]) + ' ' +  // <d>
         numberToLongString(mat[12]) + ' ' +  // <e>
         numberToLongString(mat[13]) +        // <f>
         ')';

--- a/test/js/apply-preserving-inline-style.js
+++ b/test/js/apply-preserving-inline-style.js
@@ -4,9 +4,15 @@ suite('apply-preserving-inline-style', function() {
     ensureStyleIsPatched(this.element);
     this.style = this.element.style;
     document.documentElement.appendChild(this.element);
+    this.svgContainer = document.createElementNS(
+        'http://www.w3.org/2000/svg', 'svg');
+    document.documentElement.appendChild(this.svgContainer);
+    window._webAnimationsUpdateSvgTransformAttr = null;
   });
   teardown(function() {
     document.documentElement.removeChild(this.element);
+    document.documentElement.removeChild(this.svgContainer);
+    window._webAnimationsUpdateSvgTransformAttr = null;
   });
 
   test('Style is patched', function() {
@@ -68,5 +74,111 @@ suite('apply-preserving-inline-style', function() {
     assert.equal(this.style.length, 2);
     this.style.cssText = 'top: 0px';
     assert.equal(this.style.length, 1);
+  });
+  test('Detect SVG transform compatibility', function() {
+    var win = {navigator: {userAgent: ''}};
+    function agent(str) {
+      win._webAnimationsUpdateSvgTransformAttr = null;
+      win.navigator.userAgent = str;
+    }
+    // Unknown data: assume that transforms supported.
+    assert.equal(updateSvgTransformAttr(win), false);
+    // Chrome: transforms supported.
+    agent('Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E)' +
+        ' AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.20' +
+        ' Mobile Safari/537.36');
+    assert.equal(updateSvgTransformAttr(win), false);
+    // Safary: transforms supported.
+    agent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) ' +
+        'AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 ' +
+        'Safari/7046A194A');
+    assert.equal(updateSvgTransformAttr(win), false);
+    // Firefox: transforms supported.
+    agent('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) ' +
+        'Gecko/20100101 Firefox/40.1');
+    assert.equal(updateSvgTransformAttr(win), false);
+    // IE: transforms are NOT supported.
+    agent('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 7.0;' +
+        ' InfoPath.3; .NET CLR 3.1.40767; Trident/6.0; en-IN)');
+    assert.equal(updateSvgTransformAttr(win), true);
+    // Edge: transforms are NOT supported.
+    agent('Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36' +
+        ' (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36' +
+        ' Edge/12.10136');
+    assert.equal(updateSvgTransformAttr(win), true);
+  });
+  test('Set and clear transform', function() {
+    // This is not an SVG element, so CSS transform support is not consulted.
+    window._webAnimationsUpdateSvgTransformAttr = true;
+    // Set.
+    this.element.style._set('transform', 'translate(10px, 10px) scale(2)');
+    assert.equal(getComputedStyle(this.element).transform,
+        'matrix(2, 0, 0, 2, 10, 10)');
+    assert.equal(this.element.hasAttribute('transform'), false);
+    // Clear.
+    this.element.style._clear('transform');
+    assert.equal(getComputedStyle(this.element).transform, 'none');
+    assert.equal(this.element.hasAttribute('transform'), false);
+  });
+  test('Set and clear supported transform on SVG element', function() {
+    window._webAnimationsUpdateSvgTransformAttr = false;
+    var svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    ensureStyleIsPatched(svgElement);
+    this.svgContainer.appendChild(svgElement);
+    // Set.
+    svgElement.style._set('transform', 'translate(10px, 10px) scale(2)');
+    assert.equal(getComputedStyle(svgElement).transform,
+        'matrix(2, 0, 0, 2, 10, 10)');
+    assert.equal(svgElement.hasAttribute('transform'), false);
+    // Clear.
+    svgElement.style._clear('transform');
+    assert.equal(getComputedStyle(svgElement).transform, 'none');
+    assert.equal(svgElement.hasAttribute('transform'), false);
+  });
+  test('Set and clear NOT supported transform on SVG element', function() {
+    window._webAnimationsUpdateSvgTransformAttr = true;
+    var svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    ensureStyleIsPatched(svgElement);
+    this.svgContainer.appendChild(svgElement);
+    // Set.
+    svgElement.style._set('transform', 'translate(10px, 10px) scale(2)');
+    assert.equal(getComputedStyle(svgElement).transform,
+        'matrix(2, 0, 0, 2, 10, 10)');
+    assert.equal(svgElement.getAttribute('transform'),
+        'matrix(2 0 0 2 10 10)');
+    // Clear.
+    svgElement.style._clear('transform');
+    assert.equal(getComputedStyle(svgElement).transform, 'none');
+    assert.equal(svgElement.getAttribute('transform'), null);
+  });
+  test('Set and clear NOT supported prefixed transform on SVG element', function() {
+    window._webAnimationsUpdateSvgTransformAttr = true;
+    var svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    ensureStyleIsPatched(svgElement);
+    this.svgContainer.appendChild(svgElement);
+    // Set.
+    svgElement.style._set('msTransform', 'translate(10px, 10px) scale(2)');
+    assert.equal(svgElement.getAttribute('transform'),
+        'matrix(2 0 0 2 10 10)');
+    // Clear.
+    svgElement.style._clear('msTransform');
+    assert.equal(svgElement.getAttribute('transform'), null);
+  });
+  test('Restore NOT supported transform on SVG element', function() {
+    window._webAnimationsUpdateSvgTransformAttr = true;
+    var svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    svgElement.setAttribute('transform', 'matrix(2 0 0 2 0 0)');
+    ensureStyleIsPatched(svgElement);
+    this.svgContainer.appendChild(svgElement);
+    // Set.
+    svgElement.style._set('transform', 'translate(10px, 10px) scale(2)');
+    assert.equal(getComputedStyle(svgElement).transform,
+        'matrix(2, 0, 0, 2, 10, 10)');
+    assert.equal(svgElement.getAttribute('transform'),
+        'matrix(2 0 0 2 10 10)');
+    // Clear.
+    svgElement.style._clear('transform');
+    assert.equal(getComputedStyle(svgElement).transform, 'none');
+    assert.equal(svgElement.getAttribute('transform'), 'matrix(2 0 0 2 0 0)');
   });
 });

--- a/test/js/apply-preserving-inline-style.js
+++ b/test/js/apply-preserving-inline-style.js
@@ -106,6 +106,10 @@ suite('apply-preserving-inline-style', function() {
         ' (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36' +
         ' Edge/12.10136');
     assert.equal(updateSvgTransformAttr(win), true);
+    // ICS Android: transforms are NOT supported.
+    agent('Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; MZ604 Build/I.7.1-45)' +
+        ' AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30');
+    assert.equal(updateSvgTransformAttr(win), true);
   });
   test('Set and clear transform', function() {
     // This is not an SVG element, so CSS transform support is not consulted.


### PR DESCRIPTION
I'd like to discuss a possible workaround for IE/Edge lack of support of `transform` styles for SVG elements. E.g. see https://connect.microsoft.com/IE/feedback/details/811744/ie11-bug-with-implementation-of-css-transforms-in-svg and https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/1173754/

As [README.md](README.md) correctly states:

> By unifying the animation features of SVG and CSS, Web Animations unlocks features previously only usable declaratively, and exposes powerful, high-performance animation capabilities to developers.

This workaround would essentially polyfill this statement for IE/Edge.

If this change is acceptable, I'll add tests, add more features (e.g. `transform-origin`) and more docs. PTAL.

Closes #83.

/cc @emarchiori @jasti
