### PR TITLE
Update test expectations for spaceless function()

### DIFF
--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -37,6 +37,9 @@ module.exports = {
 
           'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
               'assert_throws: function "function () {\n      div.animate(subtest.input, 2000);\n    }" did not throw',
+
+          'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
+              'assert_throws: function "function() {\n      div.animate(subtest.input, 2000);\n    }" did not throw',
         },
 
         'test/web-platform-tests/web-animations/interfaces/Animation/cancel.html': {
@@ -1366,6 +1369,9 @@ module.exports = {
 
           'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
               'assert_throws: function "function () {\n      div.animate(subtest.input, 2000);\n    }" did not throw',
+
+          'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
+              'assert_throws: function "function() {\n      div.animate(subtest.input, 2000);\n    }" did not throw',
         },
 
         'test/web-platform-tests/web-animations/interfaces/Animatable/animate-effect.html': {


### PR DESCRIPTION
test/web-platform-tests/web-animations/interfaces/Animatable/animate-basic.html
was failing on my Desktop with

	Failed differently:
	  Test: 'Element.animate() does not accept property-indexed keyframes with an invalid easing value'
	  Expected: 'assert_throws: function "function () {\n      div.animate(subtest.input, 2000);\n    }" did not throw'
	  Actual:   'assert_throws: function "function() {\n      div.animate(subtest.input, 2000);\n    }" did not throw'

This is a simple change in function serialization.