### PR TITLE
Do not write to readonly _isFinished

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -191,7 +191,6 @@
       this._inEffect = false;
       this._idle = true;
       this._paused = false;
-      this._isFinished = true;
       this._finishedFlag = true;
       this._currentTime = 0;
       this._startTime = null;


### PR DESCRIPTION
The property _isFinished is readonly. cancel() should not attempt to
write to the property.

resolves #160