### PR TITLE
propertyName could be undefined when using in old browser. Validation

### DIFF
--- a/src/apply-preserving-inline-style.js
+++ b/src/apply-preserving-inline-style.js
@@ -222,11 +222,13 @@
 
   scope.apply = function(element, property, value) {
     ensureStyleIsPatched(element);
-    element.style._set(scope.propertyName(property), value);
+    if (typeof scope.propertyName == 'function') {
+        element.style._set(scope.propertyName(property), value);
+    }
   };
 
   scope.clear = function(element, property) {
-    if (element._webAnimationsPatchedStyle) {
+    if (element._webAnimationsPatchedStyle && typeof scope.propertyName == 'function') {
       element.style._clear(scope.propertyName(property));
     }
   };


### PR DESCRIPTION
is added in to avoid error: undefined is not a function (evaluating
'n.style._clear(t.propertyName(e))'