### PR TITLE
Update minimatch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "*.min.js.map"
   ],
   "devDependencies": {
+    "minimatch": "^3.0.4",
     "mocha": "1.21.4",
     "chai": "^1.9.1",
     "grunt": "~0.4.5",


### PR DESCRIPTION
`npm install`
was giving the warning
`npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2
or higher to avoid a RegExp DoS issue`

We avoid the warning by using a recent minimatch version.