### PR TITLE
Fix the wrapping IIFE of the prod bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
     var record = config.uglify[target];
     record.options.sourceMapIn = source + '.map';
     record.options.banner = grunt.file.read('templates/boilerplate');
-    record.options.wrap = true;
+    record.options.enclose = true;
     record.options.compress.dead_code = true;
     record.options.mangle = { eval: true };
     return name;


### PR DESCRIPTION
Currently, the semantics of [line 59 in `Gruntfile.js`](https://github.com/web-animations/web-animations-js/blob/ae52749433415fe979396bb82e7e5a0bdf9a115a/Gruntfile.js#L59) is - expose the library as a global called `true`. This causes two problems:

1. The wrapping mechanism of uglify breaks in strict mode (more below)
2. There's a leaking global variable called `true`

The used version of uglify wraps the code in the following construct:

```js
"(function(" + parameters.join(",") + "){ '$ORIG'; })(" + args.join(",") + ")";
```

The IIFE passes the global `this` to a function and later tries to set the property name that we've assigned to `wrap`. This works fine in non-strict cases. The only side effect is the global `window.true` that we set to an empty object. In strict mode, however, global `this` equals to `undefined`. We try to set `undefined['true']` which cases a runtime error.

We noticed the above scenario after enabling differential loading with `script[type="module"]`, which uses strict mode by default.

It'll be fantastic if we can release the fix today, so we don't block the CLI release.

Side note, the wrap function of uglify is fixed for strict mode [here](https://github.com/mishoo/UglifyJS2/pull/1811/files#diff-da84828c4bd7834c0040b0bbb51acdec). Maybe update of `grunt` and `grunt-contrib-uglify` is worth it.